### PR TITLE
(fix) remove related links section

### DIFF
--- a/app/views/leave-feedback/start.html
+++ b/app/views/leave-feedback/start.html
@@ -57,28 +57,5 @@ Give feedback to Ofsted about a school
 
   </div>
 
-  <div class="govuk-grid-column-one-third">
-
-    <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
-
-    <aside class="app-related-items" role="complementary">
-      <h2 class="govuk-heading-m" id="subsection-title">
-          Related links
-        </h2>
-      <nav role="navigation" aria-labelledby="subsection-title">
-        <ul class="govuk-list govuk-!-font-size-16">
-          <li>
-            <a href="https://www.gov.uk/complain-about-school">Complain about a school</a>
-          </li>
-          <!-- <li>
-            <a href="#" class="govuk-link govuk-!-font-weight-bold">
-                More <span class="govuk-visually-hidden">in Subsection</span>
-              </a>
-          </li> -->
-        </ul>
-      </nav>
-    </aside>
-
-  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/qwZx0GpE/285-remove-related-links-on-the-start-page

## Changes in this PR:
Removes "Related links" section on start page

## Screenshots of UI changes:

### Before
![Screenshot_2019-03-28_at_09 50 46](https://user-images.githubusercontent.com/822507/55229362-ae621d80-5214-11e9-8392-600ddb8e874c.png)

### After
<img width="1042" alt="Screenshot 2019-03-29 at 11 18 15" src="https://user-images.githubusercontent.com/822507/55229313-8ffc2200-5214-11e9-9205-2cadd2e2f39a.png">