### PR TITLE
(fix) make page titles dynamic

### DIFF
--- a/app/views/leave-feedback/additional-feedback.html
+++ b/app/views/leave-feedback/additional-feedback.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Additional feedback — Give feedback to Ofsted about a school
+Do you have any additional feedback? — {{ serviceName }}
 {% endblock %}
 
 {% from "back-link/macro.njk" import govukBackLink %}

--- a/app/views/leave-feedback/check-your-answers.html
+++ b/app/views/leave-feedback/check-your-answers.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Check your answers — Give feedback to Ofsted about a school
+Check your answers before sending your feedback — {{ serviceName }}
 {% endblock %}
 
 {% from "summary-list/macro.njk" import govukSummaryList %}

--- a/app/views/leave-feedback/confirmation.html
+++ b/app/views/leave-feedback/confirmation.html
@@ -5,7 +5,7 @@
 {% from "panel/macro.njk" import govukPanel %}
 
 {% block pageTitle %}
-  Feedback submitted — Give feedback to Ofsted about a school
+Feedback submitted — {{ serviceName }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/leave-feedback/questions/question.html
+++ b/app/views/leave-feedback/questions/question.html
@@ -5,7 +5,7 @@
 {% from "back-link/macro.njk" import govukBackLink %}
 
 {% block pageTitle %}
-My child feels safe at this school — Give feedback to Ofsted about a school
+{{ question.text }} — {{ serviceName }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/leave-feedback/sharing-information-consent.html
+++ b/app/views/leave-feedback/sharing-information-consent.html
@@ -6,7 +6,7 @@
 {% from "back-link/macro.njk" import govukBackLink %}
 
 {% block pageTitle %}
-Consent to using your answers — Give feedback to schools
+What happens with your feedback — {{ serviceName }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/leave-feedback/start.html
+++ b/app/views/leave-feedback/start.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Give feedback to Ofsted about a school
+{{ serviceName }}
 {% endblock %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/rHolPTXk/256-make-page-titles-dynamic

## Changes in this PR:
- use `question.text` variable for the dynamic question page titles
- hardcode one-off titles
- use the `serviceName` variable from config.js as a suffix to all titles