### PR TITLE
(feature) adds fictional school name to the flow

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -29,6 +29,9 @@ module.exports = {
   cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>',
 
   // Enable or disable Browser Sync
-  useBrowserSync: 'true'
+  useBrowserSync: 'true',
+
+  // School name for testimng sessions
+  schoolName: 'Greenwood High School'
 
 }

--- a/app/data/questions.json
+++ b/app/data/questions.json
@@ -2,7 +2,7 @@
   "data": [
     {
       "id": 1,
-      "text": "My child is happy at this school",
+      "text": "My child is happy at Greenwood High School",
       "hintText": null,
       "answers": [
         {
@@ -25,7 +25,7 @@
     },
     {
       "id": 2,
-      "text": "My child feels safe at this school",
+      "text": "My child feels safe at Greenwood High School",
       "hintText": null,
       "answers": [
         {
@@ -48,7 +48,7 @@
     },
     {
       "id": 3,
-      "text": "My child’s school does its best to ensure that they reach their potential",
+      "text": "Greenwood High School does its best to ensure that they reach their potential",
       "hintText": null,
       "answers": [
         {
@@ -71,7 +71,7 @@
     },
     {
       "id": 4,
-      "text": "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at this school",
+      "text": "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at Greenwood High School",
       "hintText": null,
       "answers": [
         {
@@ -105,7 +105,7 @@
     },
     {
       "id": 5,
-      "text": "My child’s school has high expectations for all its pupils",
+      "text": "Greenwood High School has high expectations for all its pupils",
       "hintText": null,
       "answers": [
         {
@@ -128,7 +128,7 @@
     },
     {
       "id": 6,
-      "text": "There have been a high number of staff changes at my child’s school over the last year",
+      "text": "There have been a high number of staff changes at Greenwood High School over the last year",
       "hintText": null,
       "answers": [
         {
@@ -151,7 +151,7 @@
     },
     {
       "id": 7,
-      "text": "My child has the opportunity to explore extracurricular interests at this school",
+      "text": "My child has the opportunity to explore extracurricular interests at Greenwood High School",
       "hintText": "e.g.in preschool/lunchtime/afterschool clubs and societies",
       "answers": [
         {
@@ -174,7 +174,7 @@
     },
     {
       "id": 8,
-      "text": "My child’s school is helping them become a successful, rounded person",
+      "text": "Greenwood High School is helping my child to become a successful, rounded person",
       "hintText": null,
       "answers": [
         {
@@ -197,7 +197,7 @@
     },
     {
       "id": 9,
-      "text": "My child’s school takes the need for good behaviour seriously",
+      "text": "Greenwood High School takes the need for good behaviour seriously",
       "hintText": null,
       "answers": [
         {
@@ -220,7 +220,7 @@
     },
     {
       "id": 10,
-      "text": "I am confident that if my child was bullied, the school would stop it happening",
+      "text": "I am confident that if my child was bullied, Greenwood High School would stop it happening",
       "hintText": null,
       "answers": [
         {
@@ -243,7 +243,7 @@
     },
     {
       "id": 11,
-      "text": "If I had a concern, the school would take it seriously",
+      "text": "If I had a concern, Greenwood High School would take it seriously",
       "hintText": null,
       "answers": [
         {
@@ -266,7 +266,7 @@
     },
     {
       "id": 12,
-      "text": "The school updates me regularly about how my child is getting on",
+      "text": "Greenwood High School updates me regularly about how my child is getting on",
       "hintText": null,
       "answers": [
         {
@@ -289,7 +289,7 @@
     },
     {
       "id": 13,
-      "text": "My school makes me aware of what my child should be able to know and do at this stage",
+      "text": "Greenwood High School makes me aware of what my child should be able to know and do at this stage",
       "hintText": null,
       "answers": [
         {
@@ -312,7 +312,7 @@
     },
     {
       "id": 14,
-      "text": "I would recommend this school to another parent",
+      "text": "I would recommend Greenwood High School to another parent",
       "hintText": null,
       "answers": [
         {

--- a/app/routes.js
+++ b/app/routes.js
@@ -84,20 +84,20 @@ router.post('/leave-feedback/confirmation', function(req, res) {
 
   // create an object that gets each answer from allAnswers and assigns it to a key that matches those in the Notify template
   var personalisation = {
-    'answer1': allAnswers[0],
-    'answer2': allAnswers[1],
-    'answer3': allAnswers[2],
-    'answer4': allAnswers[3],
-    'answer5': allAnswers[4],
-    'answer6': allAnswers[5],
-    'answer7': allAnswers[6],
-    'answer8': allAnswers[7],
-    'answer9': allAnswers[8],
-    'answer10': allAnswers[9],
-    'answer11': allAnswers[10],
-    'answer12': allAnswers[11],
-    'answer13': allAnswers[12],
-    'answer14': allAnswers[13],
+    'answer1': questions.data[0].text + ": " + allAnswers[0],
+    'answer2': questions.data[1].text + ": " + allAnswers[1],
+    'answer3': questions.data[2].text + ": " + allAnswers[2],
+    'answer4': questions.data[3].text + ": " + allAnswers[3],
+    'answer5': questions.data[4].text + ": " + allAnswers[4],
+    'answer6': questions.data[5].text + ": " + allAnswers[5],
+    'answer7': questions.data[6].text + ": " + allAnswers[6],
+    'answer8': questions.data[7].text + ": " + allAnswers[7],
+    'answer9': questions.data[8].text + ": " + allAnswers[8],
+    'answer10': questions.data[9].text + ": " + allAnswers[9],
+    'answer11': questions.data[10].text + ": " + allAnswers[10],
+    'answer12': questions.data[11].text + ": " + allAnswers[11],
+    'answer13': questions.data[12].text + ": " + allAnswers[12],
+    'answer14': questions.data[13].text + ": " + allAnswers[13],
     'additional-feedback': req.session.data['additional-feedback']
   }
 

--- a/app/views/leave-feedback/additional-feedback.html
+++ b/app/views/leave-feedback/additional-feedback.html
@@ -44,7 +44,7 @@ Do you have any additional feedback? — {{ serviceName }}
           classes: "govuk-label--xl"
         },
         hint: {
-          html: "<p class='govuk-hint'>You can add more detail to your answers or give feedback on any aspect of the school. It will be read by the Ofsted inspector and the school.</p> <p class='govuk-hint'>You can come back and edit your feedback at any time before you send it. There is a 1000 character limit.</p> <p class='govuk-hint'>If you do not have any additional feedback, you can continue.</p>"
+          html: "<p class='govuk-hint'>You can add more detail to your answers or give feedback on any aspect of Greenwood High School. It will be read by the Ofsted inspector and the school.</p> <p class='govuk-hint'>You can come back and edit your feedback at any time before you send it. There is a 1000 character limit.</p> <p class='govuk-hint'>If you do not have any additional feedback, you can continue.</p>"
         },
         rows: 10,
         value: data["additional-feedback"]

--- a/app/views/leave-feedback/check-your-answers.html
+++ b/app/views/leave-feedback/check-your-answers.html
@@ -84,7 +84,7 @@ Check your answers before sending your feedback — {{ serviceName }}
 
     <h2 class="govuk-heading-m">Send your feedback</h2>
 
-    <p class="govuk-body">Your feedback and comments will be made anonymous and sent to Ofsted and the school.</p>
+    <p class="govuk-body">Your feedback and comments will be made anonymous and sent to Ofsted and {{ schoolName }}.</p>
 
     <p class="govuk-body">By giving feedback you give your consent to Ofsted seeing and using your responses in reports.</p>
 

--- a/app/views/leave-feedback/sharing-information-consent.html
+++ b/app/views/leave-feedback/sharing-information-consent.html
@@ -39,7 +39,7 @@ What happens with your feedback — {{ serviceName }}
 
     <h1 class="govuk-heading-l">What happens with your feedback</h1>
 
-    <p class="govuk-body">All feedback is anonymised and will be read by an Ofsted inspector to help them understand what a school is like. Ofsted also uses this information to make decisions about which schools to inspect and when.</p>
+    <p class="govuk-body">All feedback is anonymised and will be read by an Ofsted inspector to help them understand what {{ schoolName }} is like. Ofsted also uses this information to make decisions about which schools to inspect and when.</p>
 
     <p class="govuk-body">By giving feedback you give your consent to Ofsted seeing your responses.</p>
 

--- a/server.js
+++ b/server.js
@@ -178,6 +178,7 @@ app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
+app.locals.schoolName = config.schoolName
 // extensionConfig sets up variables used to add the scripts and stylesheets to each page.
 app.locals.extensionConfig = extensions.getAppConfig()
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/5VJjBbZU/303-users-can-see-what-school-theyre-providing-feedback-for

## Changes in this PR:

For testing, this commit adds a fictional school name to the flow:

- dynamically where possible
- hardcoded otherwise
- also changes slightly the way questions and answers are passed to Notify, i.e. uses the text from questions.json rather than set in the Notify template

## Screenshots of UI changes:

### Before
<img width="693" alt="before" src="https://user-images.githubusercontent.com/822507/55345645-53e0ef80-54a8-11e9-8555-86939631ace7.png">

### After
<img width="670" alt="after" src="https://user-images.githubusercontent.com/822507/55345662-622f0b80-54a8-11e9-915b-64380ef38117.png">
