### PR TITLE
Changed email copy to be a question

### DIFF
--- a/app/views/leave-feedback/sharing-information-consent.html
+++ b/app/views/leave-feedback/sharing-information-consent.html
@@ -67,13 +67,10 @@ What happens with your feedback — {{ serviceName }}
       name: "get-email",
       fieldset: {
         legend: {
-          text: "Get a copy of your responses",
+          text: "Do you want your feedback emailed to you?",
           isPageHeading: true,
           classes: "govuk-fieldset__legend--m"
         }
-      },
-      hint: {
-        text: "Provide your email address to receive a copy of what you said about Greenwood High School to Ofsted."
       },
       items: [
         {


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/GaBEFxnZ

## Changes in this PR:
We wanted the email opt in to be better and easier for the user to understand. We have iterated few options of the opt in copy heading, or adding a checkbox with “I don’t want to receive an email”.

We’ve decided these options didn’t work well enough for the interaction.

After checking with gov uk design system guide, we decided to keep the radio options and change the heading to be a simpler question, and remove unnecessary hint text.

## Screenshots of changes:
<img width="928" alt="Screenshot 2019-04-09 at 12 07 55" src="https://user-images.githubusercontent.com/2632224/55796212-4e476300-5ac1-11e9-9ce9-0ccdc10b63b4.png">

