### PR TITLE
(fix) removes school name from most questions

### DIFF
--- a/app/data/questions.json
+++ b/app/data/questions.json
@@ -16,14 +16,14 @@
     },
     {
       "id": 3,
-      "text": "Greenwood High School does its best to ensure that my child reaches their potential",
+      "text": "The school does its best to ensure that my child reaches their potential",
       "page-url": "my-child-can-reach-potential",
       "backLink": "my-child-feels-safe",
       "next": "school-makes-me-aware"
     },
     {
       "id": 4,
-      "text": "Greenwood High School tells me what my child will be learning in the forthcoming term or year",
+      "text": "The school tells me what my child will be learning in the forthcoming term or year",
       "page-url": "school-makes-me-aware",
       "backLink": "my-child-can-reach-potential",
       "next": "my-child-has-send"
@@ -37,49 +37,49 @@
     },
     {
       "id": 6,
-      "text": "There have been a high number of teaching staff changes at Greenwood High School over the last year",
+      "text": "There have been a high number of teaching staff changes at the school over the last year",
       "page-url": "school-staff-changes",
       "backLink": "my-child-has-send",
       "next": "school-extracurricular-interests"
     },
     {
       "id": 7,
-      "text": "Greenwood High School offers clubs and activities during lunchtime, before or after school",
+      "text": "The school offers clubs and activities during lunchtime, before or after school",
       "page-url": "school-extracurricular-interests",
       "backLink": "school-staff-changes",
       "next": "my-child-life-skills"
     },
     {
       "id": 8,
-      "text": "Greenwood High School is also helping them learn life skills, such as responsibility",
+      "text": "The school is also helping them learn life skills, such as responsibility",
       "page-url": "my-child-life-skills",
       "backLink": "school-extracurricular-interests",
       "next": "school-good-behaviour"
     },
     {
       "id": 9,
-      "text": "Greenwood High School is consistent in its approach to good behaviour",
+      "text": "The school is consistent in its approach to good behaviour",
       "page-url": "school-good-behaviour",
       "backLink": "my-child-life-skills",
       "next": "my-child-bullied"
     },
     {
       "id": 10,
-      "text": "I am confident that if my child was bullied, Greenwood High School would stop it happening",
+      "text": "I am confident that if my child was bullied, the school would stop it happening",
       "page-url": "my-child-bullied",
       "backLink": "school-good-behaviour",
       "next": "school-my-concerns"
     },
     {
       "id": 11,
-      "text": "Greenwood High School makes it easy for me to talk to them if I have a concern",
+      "text": "The school makes it easy for me to talk to them if I have a concern",
       "page-url": "school-my-concerns",
       "backLink": "my-child-bullied",
       "next": "school-updates-me"
     },
     {
       "id": 12,
-      "text": "Greenwood High School updates me regularly about how my child is getting on",
+      "text": "The school updates me regularly about how my child is getting on",
       "page-url": "school-updates-me",
       "backLink": "school-my-concerns",
       "next": "my-child-at-boarding-school"

--- a/app/views/leave-feedback/questions/additional-feedback-2.html
+++ b/app/views/leave-feedback/questions/additional-feedback-2.html
@@ -44,7 +44,7 @@ Do you have any additional feedback? — {{ serviceName }}
           classes: "govuk-label--xl"
         },
         hint: {
-          html: "<p class='govuk-hint'>You can add more detail to your answers or give feedback on any aspect of Greenwood High School. It will be read by the Ofsted inspector and the school.</p> <p class='govuk-hint'>You can come back and edit your feedback at any time before you send it. There is a 1000 character limit.</p> <p class='govuk-hint'>If you do not have any additional feedback, you can continue.</p>"
+          html: "<p class='govuk-hint'>You can add more detail to your answers or give feedback on any aspect of the school. It will be read by the Ofsted inspector and the school.</p> <p class='govuk-hint'>You can come back and edit your feedback at any time before you send it. There is a 1000 character limit.</p> <p class='govuk-hint'>If you do not have any additional feedback, you can continue.</p>"
         },
         rows: 10,
         value: data["additional-feedback-2"]

--- a/app/views/leave-feedback/questions/additional-feedback.html
+++ b/app/views/leave-feedback/questions/additional-feedback.html
@@ -44,7 +44,7 @@ Do you have any additional feedback? — {{ serviceName }}
           classes: "govuk-label--xl"
         },
         hint: {
-          html: "<p class='govuk-hint'>You can add more detail to your answers or give feedback on any aspect of Greenwood High School. It will be read by the Ofsted inspector and the school.</p> <p class='govuk-hint'>You can come back and edit your feedback at any time before you send it. There is a 1000 character limit.</p> <p class='govuk-hint'>If you do not have any additional feedback, you can continue.</p>"
+          html: "<p class='govuk-hint'>You can add more detail to your answers or give feedback on any aspect of the school. It will be read by the Ofsted inspector and the school.</p> <p class='govuk-hint'>You can come back and edit your feedback at any time before you send it. There is a 1000 character limit.</p> <p class='govuk-hint'>If you do not have any additional feedback, you can continue.</p>"
         },
         rows: 10,
         value: data["additional-feedback"]

--- a/app/views/leave-feedback/questions/my-child-bullied-2.html
+++ b/app/views/leave-feedback/questions/my-child-bullied-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "I am confident that if my child was bullied, Greenwood High School would stop it happening" %}
+{% set pageTitle = "I am confident that if my child was bullied, The school would stop it happening" %}
 {% set questionNumber = "10" %}
-{% set questionText = "I am confident that if my child was bullied, Greenwood High School would stop it happening" %}
+{% set questionText = "I am confident that if my child was bullied, The school would stop it happening" %}
 {% set questionSanitised = "my-child-bullied-2" %}
 {% set backLink = "school-good-behaviour-2" %}
 {% set nextPage = "school-my-concerns-2" %}

--- a/app/views/leave-feedback/questions/my-child-bullied.html
+++ b/app/views/leave-feedback/questions/my-child-bullied.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "I am confident that if my child was bullied, Greenwood High School would stop it happening" %}
+{% set pageTitle = "I am confident that if my child was bullied, The school would stop it happening" %}
 {% set questionNumber = "10" %}
-{% set questionText = "I am confident that if my child was bullied, Greenwood High School would stop it happening" %}
+{% set questionText = "I am confident that if my child was bullied, The school would stop it happening" %}
 {% set questionSanitised = "my-child-bullied" %}
 {% set backLink = "school-good-behaviour" %}
 {% set nextPage = "school-my-concerns" %}

--- a/app/views/leave-feedback/questions/my-child-can-reach-potential-2.html
+++ b/app/views/leave-feedback/questions/my-child-can-reach-potential-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School does its best to ensure that my child reaches their potential" %}
+{% set pageTitle = "The school does its best to ensure that my child reaches their potential" %}
 {% set questionNumber = "3" %}
-{% set questionText = "Greenwood High School does its best to ensure that my child reaches their potential" %}
+{% set questionText = "The school does its best to ensure that my child reaches their potential" %}
 {% set questionSanitised = "my-child-can-reach-potential-2" %}
 {% set backLink = "my-child-feels-safe-2" %}
 {% set nextPage = "school-makes-me-aware-2" %}

--- a/app/views/leave-feedback/questions/my-child-can-reach-potential.html
+++ b/app/views/leave-feedback/questions/my-child-can-reach-potential.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School does its best to ensure that my child reaches their potential" %}
+{% set pageTitle = "The school does its best to ensure that my child reaches their potential" %}
 {% set questionNumber = "3" %}
-{% set questionText = "Greenwood High School does its best to ensure that my child reaches their potential" %}
+{% set questionText = "The school does its best to ensure that my child reaches their potential" %}
 {% set questionSanitised = "my-child-can-reach-potential" %}
 {% set backLink = "my-child-feels-safe" %}
 {% set nextPage = "school-makes-me-aware" %}

--- a/app/views/leave-feedback/questions/my-child-has-send-2.html
+++ b/app/views/leave-feedback/questions/my-child-has-send-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at Greenwood High School" %}
+{% set pageTitle = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at the school" %}
 {% set questionNumber = "5" %}
-{% set questionText = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at Greenwood High School" %}
+{% set questionText = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at the school" %}
 {% set questionSanitised = "my-child-has-send-2" %}
 {% set backLink = "school-makes-me-aware-2" %}
 {% set nextPage = "school-staff-changes-2" %}

--- a/app/views/leave-feedback/questions/my-child-has-send.html
+++ b/app/views/leave-feedback/questions/my-child-has-send.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at Greenwood High School" %}
+{% set pageTitle = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at the school" %}
 {% set questionNumber = "5" %}
-{% set questionText = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at Greenwood High School" %}
+{% set questionText = "My child has SEND (Special Educational Needs and Disabilities), and I believe they are being helped to succeed at the school" %}
 {% set questionSanitised = "my-child-has-send" %}
 {% set backLink = "school-makes-me-aware" %}
 {% set nextPage = "school-staff-changes" %}

--- a/app/views/leave-feedback/questions/my-child-life-skills-2.html
+++ b/app/views/leave-feedback/questions/my-child-life-skills-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School is also helping them learn life skills, such as responsibility" %}
+{% set pageTitle = "The school is also helping them learn life skills, such as responsibility" %}
 {% set questionNumber = "8" %}
-{% set questionText = "Greenwood High School is also helping them learn life skills, such as responsibility" %}
+{% set questionText = "The school is also helping them learn life skills, such as responsibility" %}
 {% set questionSanitised = "my-child-life-skills-2" %}
 {% set backLink = "school-extracurricular-interests-2" %}
 {% set nextPage = "school-good-behaviour-2" %}

--- a/app/views/leave-feedback/questions/my-child-life-skills.html
+++ b/app/views/leave-feedback/questions/my-child-life-skills.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School is also helping them learn life skills, such as responsibility" %}
+{% set pageTitle = "The school is also helping them learn life skills, such as responsibility" %}
 {% set questionNumber = "8" %}
-{% set questionText = "Greenwood High School is also helping them learn life skills, such as responsibility" %}
+{% set questionText = "The school is also helping them learn life skills, such as responsibility" %}
 {% set questionSanitised = "my-child-life-skills" %}
 {% set backLink = "school-extracurricular-interests" %}
 {% set nextPage = "school-good-behaviour" %}

--- a/app/views/leave-feedback/questions/school-extracurricular-interests-2.html
+++ b/app/views/leave-feedback/questions/school-extracurricular-interests-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School offers clubs and activities during lunchtime, before or after school" %}
+{% set pageTitle = "The school offers clubs and activities during lunchtime, before or after school" %}
 {% set questionNumber = "7" %}
-{% set questionText = "Greenwood High School offers clubs and activities during lunchtime, before or after school" %}
+{% set questionText = "The school offers clubs and activities during lunchtime, before or after school" %}
 {% set questionSanitised = "school-extracurricular-interests-2" %}
 {% set backLink = "school-staff-changes-2" %}
 {% set nextPage = "my-child-life-skills-2" %}

--- a/app/views/leave-feedback/questions/school-extracurricular-interests.html
+++ b/app/views/leave-feedback/questions/school-extracurricular-interests.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School offers clubs and activities during lunchtime, before or after school" %}
+{% set pageTitle = "The school offers clubs and activities during lunchtime, before or after school" %}
 {% set questionNumber = "7" %}
-{% set questionText = "Greenwood High School offers clubs and activities during lunchtime, before or after school" %}
+{% set questionText = "The school offers clubs and activities during lunchtime, before or after school" %}
 {% set questionSanitised = "school-extracurricular-interests" %}
 {% set backLink = "school-staff-changes" %}
 {% set nextPage = "my-child-life-skills" %}

--- a/app/views/leave-feedback/questions/school-good-behaviour-2.html
+++ b/app/views/leave-feedback/questions/school-good-behaviour-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School is consistent in its approach to good behaviour" %}
+{% set pageTitle = "The school is consistent in its approach to good behaviour" %}
 {% set questionNumber = "9" %}
-{% set questionText = "Greenwood High School is consistent in its approach to good behaviour" %}
+{% set questionText = "The school is consistent in its approach to good behaviour" %}
 {% set questionSanitised = "school-good-behaviour-2" %}
 {% set backLink = "my-child-life-skills-2" %}
 {% set nextPage = "my-child-bullied-2" %}

--- a/app/views/leave-feedback/questions/school-good-behaviour.html
+++ b/app/views/leave-feedback/questions/school-good-behaviour.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School is consistent in its approach to good behaviour" %}
+{% set pageTitle = "The school is consistent in its approach to good behaviour" %}
 {% set questionNumber = "9" %}
-{% set questionText = "Greenwood High School is consistent in its approach to good behaviour" %}
+{% set questionText = "The school is consistent in its approach to good behaviour" %}
 {% set questionSanitised = "school-good-behaviour" %}
 {% set backLink = "my-child-life-skills" %}
 {% set nextPage = "my-child-bullied" %}

--- a/app/views/leave-feedback/questions/school-makes-me-aware-2.html
+++ b/app/views/leave-feedback/questions/school-makes-me-aware-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School tells me what my child will be learning in the forthcoming term or year" %}
+{% set pageTitle = "The school tells me what my child will be learning in the forthcoming term or year" %}
 {% set questionNumber = "4" %}
-{% set questionText = "Greenwood High School tells me what my child will be learning in the forthcoming term or year" %}
+{% set questionText = "The school tells me what my child will be learning in the forthcoming term or year" %}
 {% set questionSanitised = "school-makes-me-aware-2" %}
 {% set backLink = "my-child-can-reach-potential-2" %}
 {% set nextPage = "my-child-has-send-2" %}

--- a/app/views/leave-feedback/questions/school-makes-me-aware.html
+++ b/app/views/leave-feedback/questions/school-makes-me-aware.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School tells me what my child will be learning in the forthcoming term or year" %}
+{% set pageTitle = "The school tells me what my child will be learning in the forthcoming term or year" %}
 {% set questionNumber = "4" %}
-{% set questionText = "Greenwood High School tells me what my child will be learning in the forthcoming term or year" %}
+{% set questionText = "The school tells me what my child will be learning in the forthcoming term or year" %}
 {% set questionSanitised = "school-makes-me-aware" %}
 {% set backLink = "my-child-can-reach-potential" %}
 {% set nextPage = "my-child-has-send" %}

--- a/app/views/leave-feedback/questions/school-my-concerns-2.html
+++ b/app/views/leave-feedback/questions/school-my-concerns-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School makes it easy for me to talk to them if I have a concern" %}
+{% set pageTitle = "The school makes it easy for me to talk to them if I have a concern" %}
 {% set questionNumber = "11" %}
-{% set questionText = "Greenwood High School makes it easy for me to talk to them if I have a concern" %}
+{% set questionText = "The school makes it easy for me to talk to them if I have a concern" %}
 {% set questionSanitised = "school-my-concerns-2" %}
 {% set backLink = "my-child-bullied-2" %}
 {% set nextPage = "school-updates-me-2" %}

--- a/app/views/leave-feedback/questions/school-my-concerns.html
+++ b/app/views/leave-feedback/questions/school-my-concerns.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School makes it easy for me to talk to them if I have a concern" %}
+{% set pageTitle = "The school makes it easy for me to talk to them if I have a concern" %}
 {% set questionNumber = "11" %}
-{% set questionText = "Greenwood High School makes it easy for me to talk to them if I have a concern" %}
+{% set questionText = "The school makes it easy for me to talk to them if I have a concern" %}
 {% set questionSanitised = "school-my-concerns" %}
 {% set backLink = "my-child-bullied" %}
 {% set nextPage = "school-updates-me" %}

--- a/app/views/leave-feedback/questions/school-staff-changes-2.html
+++ b/app/views/leave-feedback/questions/school-staff-changes-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "There have been a high number of teaching staff changes at Greenwood High School over the last year" %}
+{% set pageTitle = "There have been a high number of teaching staff changes at the school over the last year" %}
 {% set questionNumber = "6" %}
-{% set questionText = "There have been a high number of teaching staff changes at Greenwood High School over the last year" %}
+{% set questionText = "There have been a high number of teaching staff changes at the school over the last year" %}
 {% set questionSanitised = "school-staff-changes-2" %}
 {% set backLink = "my-child-has-send-2" %}
 {% set nextPage = "school-extracurricular-interests-2" %}

--- a/app/views/leave-feedback/questions/school-staff-changes.html
+++ b/app/views/leave-feedback/questions/school-staff-changes.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "There have been a high number of teaching staff changes at Greenwood High School over the last year" %}
+{% set pageTitle = "There have been a high number of teaching staff changes at the school over the last year" %}
 {% set questionNumber = "6" %}
-{% set questionText = "There have been a high number of teaching staff changes at Greenwood High School over the last year" %}
+{% set questionText = "There have been a high number of teaching staff changes at the school over the last year" %}
 {% set questionSanitised = "school-staff-changes" %}
 {% set backLink = "my-child-has-send" %}
 {% set nextPage = "school-extracurricular-interests" %}

--- a/app/views/leave-feedback/questions/school-updates-me-2.html
+++ b/app/views/leave-feedback/questions/school-updates-me-2.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School updates me regularly about how my child is getting on" %}
+{% set pageTitle = "The school updates me regularly about how my child is getting on" %}
 {% set questionNumber = "12" %}
-{% set questionText = "Greenwood High School updates me regularly about how my child is getting on" %}
+{% set questionText = "The school updates me regularly about how my child is getting on" %}
 {% set questionSanitised = "school-updates-me-2" %}
 {% set backLink = "school-my-concerns-2" %}
 {% set nextPage = "my-child-at-boarding-school-2" %}

--- a/app/views/leave-feedback/questions/school-updates-me.html
+++ b/app/views/leave-feedback/questions/school-updates-me.html
@@ -4,9 +4,9 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% set pageTitle = "Greenwood High School updates me regularly about how my child is getting on" %}
+{% set pageTitle = "The school updates me regularly about how my child is getting on" %}
 {% set questionNumber = "12" %}
-{% set questionText = "Greenwood High School updates me regularly about how my child is getting on" %}
+{% set questionText = "The school updates me regularly about how my child is getting on" %}
 {% set questionSanitised = "school-updates-me" %}
 {% set backLink = "school-my-concerns" %}
 {% set nextPage = "my-child-at-boarding-school" %}


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/5VJjBbZU/303-users-can-see-what-school-theyre-providing-feedback-for#comment-5caca7eecd38b45a2d8f2b97

## Changes in this PR:

Our feeling is that the school name only needs to be in the first couple of questions to reassure the user that they’re answering the right survey.

Removing the (potentially quite long) school name also makes the questions feel less dense.