### PR TITLE
(feature) current child is clearly labelled

### DIFF
--- a/app/views/leave-feedback/questions/additional-feedback-2.html
+++ b/app/views/leave-feedback/questions/additional-feedback-2.html
@@ -32,6 +32,8 @@ Do you have any additional feedback? — {{ serviceName }}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
+    <span class="govuk-caption-xl"><strong>Child 2</strong></span>
+
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else '/leave-feedback/add-another-child' }}" method="post" class="form">
 
       {{ govukCharacterCount({

--- a/app/views/leave-feedback/questions/additional-feedback.html
+++ b/app/views/leave-feedback/questions/additional-feedback.html
@@ -32,6 +32,8 @@ Do you have any additional feedback? — {{ serviceName }}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
+    <span class="govuk-caption-xl"><strong>Child 1</strong></span>
+
     <form action="{{ '/leave-feedback/check-your-answers' if editing else '/leave-feedback/add-another-child' }}" method="post" class="form">
 
       {{ govukCharacterCount({

--- a/app/views/leave-feedback/questions/my-child-at-boarding-school-2.html
+++ b/app/views/leave-feedback/questions/my-child-at-boarding-school-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-at-boarding-school.html
+++ b/app/views/leave-feedback/questions/my-child-at-boarding-school.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-bullied-2.html
+++ b/app/views/leave-feedback/questions/my-child-bullied-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-bullied.html
+++ b/app/views/leave-feedback/questions/my-child-bullied.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-can-reach-potential-2.html
+++ b/app/views/leave-feedback/questions/my-child-can-reach-potential-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-can-reach-potential.html
+++ b/app/views/leave-feedback/questions/my-child-can-reach-potential.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-feels-safe-2.html
+++ b/app/views/leave-feedback/questions/my-child-feels-safe-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-feels-safe.html
+++ b/app/views/leave-feedback/questions/my-child-feels-safe.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-has-send-2.html
+++ b/app/views/leave-feedback/questions/my-child-has-send-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-has-send.html
+++ b/app/views/leave-feedback/questions/my-child-has-send.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-is-happy-2.html
+++ b/app/views/leave-feedback/questions/my-child-is-happy-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-is-happy.html
+++ b/app/views/leave-feedback/questions/my-child-is-happy.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-life-skills-2.html
+++ b/app/views/leave-feedback/questions/my-child-life-skills-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/my-child-life-skills.html
+++ b/app/views/leave-feedback/questions/my-child-life-skills.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-extracurricular-interests-2.html
+++ b/app/views/leave-feedback/questions/school-extracurricular-interests-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-extracurricular-interests.html
+++ b/app/views/leave-feedback/questions/school-extracurricular-interests.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-good-behaviour-2.html
+++ b/app/views/leave-feedback/questions/school-good-behaviour-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-good-behaviour.html
+++ b/app/views/leave-feedback/questions/school-good-behaviour.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-i-would-recommend-2.html
+++ b/app/views/leave-feedback/questions/school-i-would-recommend-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-i-would-recommend.html
+++ b/app/views/leave-feedback/questions/school-i-would-recommend.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-makes-me-aware-2.html
+++ b/app/views/leave-feedback/questions/school-makes-me-aware-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-makes-me-aware.html
+++ b/app/views/leave-feedback/questions/school-makes-me-aware.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-my-concerns-2.html
+++ b/app/views/leave-feedback/questions/school-my-concerns-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-my-concerns.html
+++ b/app/views/leave-feedback/questions/school-my-concerns.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-staff-changes-2.html
+++ b/app/views/leave-feedback/questions/school-staff-changes-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-staff-changes.html
+++ b/app/views/leave-feedback/questions/school-staff-changes.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-updates-me-2.html
+++ b/app/views/leave-feedback/questions/school-updates-me-2.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 2:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers-2' if editing else nextPage }}" method="post" class="form">
 

--- a/app/views/leave-feedback/questions/school-updates-me.html
+++ b/app/views/leave-feedback/questions/school-updates-me.html
@@ -32,7 +32,7 @@
       }) }}
     {% endif %}
 
-    <span class="govuk-caption-xl">Question {{ questionNumber }} of 14</span>
+    <span class="govuk-caption-xl"><strong>Child 1:</strong> Question {{ questionNumber }} of 14</span>
 
     <form action="{{ '/leave-feedback/check-your-answers' if editing else nextPage }}" method="post" class="form">
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/WpvkEuWv/307-users-know-which-child-theyre-giving-feedback-for

## Changes in this PR:
So a user know which child they are currently responding for, this PR adds hardcoded labels for "Child 1" and "Child 2" in the questions and on the additional feedback page.

## Screenshots of UI changes:

### Before
<img width="858" alt="before" src="https://user-images.githubusercontent.com/822507/55876502-b6647a80-5b8f-11e9-97af-c5f0fbb270ee.png">

### After
<img width="844" alt="after" src="https://user-images.githubusercontent.com/822507/55876508-b95f6b00-5b8f-11e9-88e5-aa1d691b0434.png">