### PR TITLE
(fix) only offer add child option if relevant

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -48,7 +48,7 @@ router.post('/leave-feedback/add-child', function(req, res) {
 
   if (addChild) {
     res.redirect('/leave-feedback/questions/my-child-is-happy-2')
-  } else if (multipleChildren) {
+  } else if (multipleChildren && addChild) {
     res.redirect('/leave-feedback/check-your-answers-2')
   } else {
     res.redirect('/leave-feedback/check-your-answers')

--- a/app/views/leave-feedback/questions/additional-feedback.html
+++ b/app/views/leave-feedback/questions/additional-feedback.html
@@ -28,13 +28,21 @@ Do you have any additional feedback? — {{ serviceName }}
   {% endif %}
 {% endblock %}
 
+{% macro addChildRoute() %}
+  {% if data['multiple-children'] == 'yes' %}
+    /leave-feedback/add-another-child
+  {% else %}
+    /leave-feedback/check-your-answers
+  {% endif %}
+{% endmacro %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <span class="govuk-caption-xl"><strong>Child 1</strong></span>
 
-    <form action="{{ '/leave-feedback/check-your-answers' if editing else '/leave-feedback/add-another-child' }}" method="post" class="form">
+    <form action="{{ '/leave-feedback/check-your-answers' if editing else addChildRoute() }}" method="post" class="form">
 
       {{ govukCharacterCount({
         name: "additional-feedback",


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/eu7QKJUc/325-bug-a-user-with-only-one-child-should-not-be-offered-the-chance-to-add-a-child

## Changes in this PR:
Unless a user states they have multiple children at a school, don’t show them the “add another child” option.
