### PR TITLE
(feature) adds a page to capture a survey code

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -21,6 +21,15 @@ router.get('/leave-feedback/sharing-information-consent', function(req, res) {
   });
 });
 
+router.post('/leave-feedback/survey-code', function(req, res) {
+  let hasSurveyCode = req.session.data['get-survey-code'] == "yes"
+  if (hasSurveyCode) {
+    res.redirect('/leave-feedback/sharing-information-consent');
+  } else {
+    res.redirect('https://get-information-schools.service.gov.uk/');
+  }
+});
+
 router.get('/leave-feedback/questions/:question', function(req, res) {
   res.render('leave-feedback/questions/' + req.params.question, {
     'editing': req.query.edit

--- a/app/views/leave-feedback/sharing-information-consent.html
+++ b/app/views/leave-feedback/sharing-information-consent.html
@@ -17,6 +17,11 @@ What happens with your feedback — {{ serviceName }}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    {{ govukBackLink({
+        text: "Back",
+        href: 'survey-code'
+      }) }}
+
     <h1 class="govuk-heading-l">What happens with your feedback</h1>
 
     <p class="govuk-body">All feedback is anonymised and will be read by an Ofsted inspector to help them understand what {{ schoolName }} is like. Ofsted also uses this information to make decisions about which schools to inspect and when.</p>

--- a/app/views/leave-feedback/start.html
+++ b/app/views/leave-feedback/start.html
@@ -51,7 +51,7 @@
 
     {{ govukButton({
         text: "Start now",
-        href: "/leave-feedback/sharing-information-consent",
+        href: "/leave-feedback/survey-code",
         classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"
       }) }}
 

--- a/app/views/leave-feedback/survey-code.html
+++ b/app/views/leave-feedback/survey-code.html
@@ -1,0 +1,90 @@
+{% extends "layout.html" %}
+
+{% from "input/macro.njk" import govukInput %}
+{% from "button/macro.njk" import govukButton %}
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{% block pageTitle %}
+Enter your survey code — {{ serviceName }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {{ govukBackLink({
+        text: "Back",
+        href: 'start'
+      }) }}
+
+    <form action="survey-code" method="post" class="form">
+
+      {% set surveyCode %}
+        {{ govukInput({
+          id: "survey-code",
+          name: "survey-code",
+          type: "survey-code",
+          value: data["survey-code"],
+          autocomplete: "survey-code",
+          classes: "govuk-input--width-5",
+          label: {
+            text: "Enter code"
+          },
+          attributes: {
+            spellcheck: "false"
+          }
+        }) }}
+    {% endset -%}
+
+    {{ govukRadios({
+      idPrefix: "get-survey-code-conditional",
+      name: "get-survey-code",
+      fieldset: {
+        legend: {
+          text: "Do you have a code given to you by the school?",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+      },
+      hint: {
+        text: "This is used to identify which school you’re giving feedback on."
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: surveyCode
+          },
+          checked: checked("get-survey-code", "yes")
+        },
+        {
+          value: "no",
+          text: "No",
+          conditional: {
+            html: "<p class='govuk-hint'>If you don’t have a code we will take you to a different service so you can find your school.</p>"
+          },
+          checked: checked("get-survey-code", "no")
+        }
+      ]
+    }) }}
+
+      {% if editing %}
+        {{ govukButton({
+          text: "Save your changes"
+        }) }}
+      {% else %}
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      {% endif %}
+
+    </form>
+
+
+  </div>
+</div>
+
+
+{% endblock %}


### PR DESCRIPTION
As a parent or carer
I need to access the service
So that I can give feedback about my child's school

## Trello card URL:
https://trello.com/c/BuIxMBrE/335-users-can-enter-a-code-to-access-the-service

## Changes in this PR:
This story is the first step of the access journey. There are two routes:

1. User has the URL (with code embedded)
2. User has a code

For the first option, users will click on a URL to access the service - and they're taken straight to the start page without needing to enter a code (we'd add it to the URL query params).

For the second option, users will get the URL via a non-digital means and will have a code. It'll be a page for the user to enter the code - afterwards, they'd be taken to the first question in the survey.

## Screenshots of UI changes:

![code](https://user-images.githubusercontent.com/822507/56193469-9cf87e00-6028-11e9-9965-25d0c04e492a.gif)